### PR TITLE
feat(ui): Catppuccin-themed UI system with swatch picker

### DIFF
--- a/configs/bin/.local/bin/dotfiles
+++ b/configs/bin/.local/bin/dotfiles
@@ -12,23 +12,37 @@ source "$INSTALL_DIR/lib/os.sh"
 # shellcheck disable=SC1091
 source "$INSTALL_DIR/lib/ui.sh"
 
+# ── Header ────────────────────────────────────────────────────────────────────
+
 show_header() {
   ui_header
+
+  # Status line: platform · active theme · date
+  local platform theme date_str
+  platform="$(detect_os)"
+  theme="$(cat "$DOTFILES_DIR/themes/current-theme" 2>/dev/null || echo "none")"
+  date_str="$(date '+%b %Y')"
+
+  printf '%s     %s · theme: %s · %s%s\n\n' \
+    "$_UI_MUTED" "$platform" "$theme" "$date_str" "$_UI_RST"
 }
+
+# ── Profile runner ────────────────────────────────────────────────────────────
 
 run_profile() {
   local profile="$1"
-
   case "$profile" in
-    wsl) bash "$INSTALL_DIR/profiles/wsl.sh" ;;
+    wsl)   bash "$INSTALL_DIR/profiles/wsl.sh" ;;
     linux) bash "$INSTALL_DIR/profiles/linux.sh" ;;
-    auto) run_profile "$(detect_os)" ;;
+    auto)  run_profile "$(detect_os)" ;;
     *)
-      echo "Unsupported install profile: $profile"
+      ui_error "Unsupported install profile: $profile"
       return 1
       ;;
   esac
 }
+
+# ── Commands ──────────────────────────────────────────────────────────────────
 
 cmd_theme() {
   bash "$DOTFILES_DIR/scripts/theme.sh" "$@"
@@ -39,37 +53,90 @@ cmd_clean_backups() {
 }
 
 cmd_update() {
-  echo "Starting update..."
+  ui_section "System Update"
 
+  # Package manager upgrade
+  export DOTFILES_SPINNER=pulse
   if grep -qi microsoft /proc/version 2>/dev/null; then
-    sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y
+    if command -v gum >/dev/null 2>&1; then
+      gum spin --spinner pulse --title "Upgrading system packages..." --show-error -- \
+        bash -c 'sudo apt update -qq && sudo apt upgrade -y && sudo apt autoremove -y'
+    else
+      sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y
+    fi
+    ui_ok "system packages"
   elif [ -f /etc/os-release ]; then
     # shellcheck disable=SC1091
     . /etc/os-release
     case "$ID" in
-      ubuntu|debian) sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y ;;
-      arch) sudo pacman -Syu --noconfirm ;;
-      fedora) sudo dnf upgrade -y ;;
+      ubuntu|debian)
+        if command -v gum >/dev/null 2>&1; then
+          gum spin --spinner pulse --title "Upgrading apt packages..." --show-error -- \
+            bash -c 'sudo apt update -qq && sudo apt upgrade -y && sudo apt autoremove -y'
+        else
+          sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y
+        fi
+        ui_ok "system packages"
+        ;;
+      arch)
+        if command -v gum >/dev/null 2>&1; then
+          gum spin --spinner pulse --title "Upgrading pacman packages..." --show-error -- \
+            sudo pacman -Syu --noconfirm
+        else
+          sudo pacman -Syu --noconfirm
+        fi
+        ui_ok "system packages"
+        ;;
+      fedora)
+        if command -v gum >/dev/null 2>&1; then
+          gum spin --spinner pulse --title "Upgrading dnf packages..." --show-error -- \
+            sudo dnf upgrade -y
+        else
+          sudo dnf upgrade -y
+        fi
+        ui_ok "system packages"
+        ;;
     esac
   fi
 
-  if command -v zsh >/dev/null 2>&1 && [ -f "$HOME/.config/zsh/.zshrc" ] && grep -q zinit "$HOME/.config/zsh/.zshrc"; then
-    zsh -i -c "zinit self-update; zinit update --all" 2>/dev/null || true
-    echo "  ✓ zinit plugins"
+  # zinit
+  if command -v zsh >/dev/null 2>&1 && [ -f "$HOME/.config/zsh/.zshrc" ] && \
+     grep -q zinit "$HOME/.config/zsh/.zshrc" 2>/dev/null; then
+    if command -v gum >/dev/null 2>&1; then
+      gum spin --spinner pulse --title "Updating zinit plugins..." --show-error -- \
+        zsh -i -c "zinit self-update; zinit update --all" 2>/dev/null || true
+    else
+      zsh -i -c "zinit self-update; zinit update --all" 2>/dev/null || true
+    fi
+    ui_ok "zinit plugins"
   fi
 
+  # mise
   if command -v mise >/dev/null 2>&1; then
-    mise up 2>/dev/null || true
-    echo "  ✓ mise tools"
+    if command -v gum >/dev/null 2>&1; then
+      gum spin --spinner pulse --title "Updating mise tools..." --show-error -- \
+        mise up 2>/dev/null || true
+    else
+      mise up 2>/dev/null || true
+    fi
+    ui_ok "mise tools"
   fi
 
+  # tmux plugins
   if [ -d "$HOME/.tmux/plugins/tpm" ]; then
-    TMUX_PLUGIN_MANAGER_PATH="$HOME/.tmux/plugins" "$HOME/.tmux/plugins/tpm/bin/install_plugins" 2>/dev/null || true
-    TMUX_PLUGIN_MANAGER_PATH="$HOME/.tmux/plugins" "$HOME/.tmux/plugins/tpm/bin/update_plugins" all 2>/dev/null || true
-    echo "  ✓ tmux plugins"
+    if command -v gum >/dev/null 2>&1; then
+      gum spin --spinner pulse --title "Updating tmux plugins..." --show-error -- \
+        bash -c 'TMUX_PLUGIN_MANAGER_PATH="$HOME/.tmux/plugins" \
+          "$HOME/.tmux/plugins/tpm/bin/update_plugins" all' 2>/dev/null || true
+    else
+      TMUX_PLUGIN_MANAGER_PATH="$HOME/.tmux/plugins" \
+        "$HOME/.tmux/plugins/tpm/bin/update_plugins" all 2>/dev/null || true
+    fi
+    ui_ok "tmux plugins"
   fi
 
-  echo "Update complete."
+  export DOTFILES_SPINNER=moon
+  ui_banner_success "Update complete" "system · zinit · mise · tmux"
 }
 
 cmd_install_base_setup() {
@@ -95,83 +162,73 @@ cmd_install() {
   fi
 
   case "${1:-}" in
-    base|base-setup)
-      cmd_install_base_setup
-      return
-      ;;
-    terminal|terminal-tools)
-      cmd_install_terminal_tools
-      return
-      ;;
-    languages)
-      bash "$INSTALL_DIR/languages/select.sh" "${@:2}"
-      return
-      ;;
-    agents|coding-agents)
-      cmd_install_coding_agents
-      return
-      ;;
-    everything|all)
-      cmd_install_everything
-      return
-      ;;
-    theme)
-      cmd_theme
-      return
-      ;;
-    clean-backups)
-      cmd_clean_backups
-      return
-      ;;
+    base|base-setup)       cmd_install_base_setup;                              return ;;
+    terminal|terminal-tools) cmd_install_terminal_tools;                        return ;;
+    languages)             bash "$INSTALL_DIR/languages/select.sh" "${@:2}";    return ;;
+    agents|coding-agents)  cmd_install_coding_agents;                           return ;;
+    everything|all)        cmd_install_everything;                              return ;;
+    theme)                 cmd_theme;                                           return ;;
+    clean-backups)         cmd_clean_backups;                                   return ;;
   esac
 
   if ! command -v gum >/dev/null 2>&1; then
-    echo "gum is required for interactive install menus."
-    echo "Run ./install.sh first."
+    printf 'gum is required for interactive install menus.\nRun ./install.sh first.\n'
+    exit 1
+  fi
+
+  # Build menu items as "label  dim-description" strings
+  # gum choose renders them; we match on label prefix.
+  local choice
+  choice=$(gum choose \
+    "Base Setup       · shell, git, bat, eza, zsh, starship" \
+    "Terminal Tools   · neovim, tmux, zellij, fzf, lazygit…" \
+    "Languages        · node, bun, go, rust, python, java…" \
+    "Coding Agents    · pi, claude, codex, gemini, copilot" \
+    "Theme            · switch the active colorscheme" \
+    "Clean Backups    · remove stale stow backup files" \
+    "Install Everything · run all categories at once" \
+    "Quit" \
+    --header "  Install / Setup")
+
+  case "$choice" in
+    Base\ Setup*)       cmd_install_base_setup ;;
+    Terminal\ Tools*)   cmd_install_terminal_tools ;;
+    Languages*)         bash "$INSTALL_DIR/languages/select.sh" ;;
+    Coding\ Agents*)    cmd_install_coding_agents ;;
+    Theme*)             cmd_theme ;;
+    Clean\ Backups*)    cmd_clean_backups ;;
+    Install\ Everything*) cmd_install_everything ;;
+    *)                  return 0 ;;
+  esac
+}
+
+# ── Main menu ─────────────────────────────────────────────────────────────────
+
+show_menu() {
+  if ! command -v gum >/dev/null 2>&1; then
+    printf 'gum is required for interactive menus. Run ./install.sh first.\n'
     exit 1
   fi
 
   local choice
   choice=$(gum choose \
-    "Base Setup" \
-    "Terminal Tools" \
-    "Languages" \
-    "Coding Agents" \
-    "Theme" \
-    "Clean Backups" \
-    "Install Everything" \
+    "Theme            · switch the active colorscheme" \
+    "Update           · upgrade system + all managed tools" \
+    "Install          · set up tools, agents & languages" \
+    "Clean Backups    · remove stale stow backup files" \
     "Quit" \
-    --header "Install / setup")
+    --header "  What would you like to do?")
 
   case "$choice" in
-    "Base Setup") cmd_install_base_setup ;;
-    "Terminal Tools") cmd_install_terminal_tools ;;
-    "Languages") bash "$INSTALL_DIR/languages/select.sh" ;;
-    "Coding Agents") cmd_install_coding_agents ;;
-    "Theme") cmd_theme ;;
-    "Clean Backups") cmd_clean_backups ;;
-    "Install Everything") cmd_install_everything ;;
-    *) return 0 ;;
+    Theme*)         cmd_theme ;;
+    Update*)        cmd_update ;;
+    Install*)       cmd_install ;;
+    Clean\ Backups*) cmd_clean_backups ;;
+    *)              return 0 ;;
   esac
 }
 
-show_menu() {
-  if ! command -v gum >/dev/null 2>&1; then
-    echo "gum is required for interactive menus. Run ./install.sh first."
-    exit 1
-  fi
-
-  local choice
-  choice=$(gum choose "Theme" "Update" "Install" "Clean Backups" "Quit" --header "What would you like to do?")
-
-  case "$choice" in
-    Theme) cmd_theme ;;
-    Update) cmd_update ;;
-    Install) cmd_install ;;
-    "Clean Backups") cmd_clean_backups ;;
-    *) return 0 ;;
-  esac
-}
+# ── Entrypoint ────────────────────────────────────────────────────────────────
 
 case "${1:-}" in
   "")
@@ -194,7 +251,7 @@ case "${1:-}" in
     cmd_clean_backups "$@"
     ;;
   *)
-    echo "Usage: dotfiles [theme|update|install|clean-backups]"
+    printf 'Usage: dotfiles [theme|update|install|clean-backups]\n' >&2
     exit 1
     ;;
 esac

--- a/configs/git/.config/git/config
+++ b/configs/git/.config/git/config
@@ -45,6 +45,10 @@
 	default = current
 	followTags = true
 	gpgSign = false
+	forceWithLease = true
+
+[fetch]
+	prune = true
 
 [pull]
 	rebase = true

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,7 @@ INSTALL_DIR="$DOTFILES_DIR/install"
 source "$INSTALL_DIR/lib/common.sh"
 # shellcheck disable=SC1091
 source "$INSTALL_DIR/lib/os.sh"
-# shellcheck disable=SC1091
-source "$INSTALL_DIR/lib/ui.sh"
+# ui.sh is already sourced transitively through common.sh
 
 DOTFILES_CLI="$DOTFILES_DIR/configs/bin/.local/bin/dotfiles"
 
@@ -41,50 +40,56 @@ ui_header
 platform="$(detect_os)"
 case "$platform" in
   wsl)
-    echo "  Platform: WSL Ubuntu"
+    printf '%s     Platform detected: %sWSL Ubuntu%s\n\n' \
+      "$_UI_MUTED" "$_UI_BLUE" "$_UI_RST"
     ;;
   linux)
-    echo "  Platform: Native Ubuntu/Debian"
+    printf '%s     Platform detected: %sNative Ubuntu / Debian%s\n\n' \
+      "$_UI_MUTED" "$_UI_BLUE" "$_UI_RST"
     ;;
   arch)
-    echo "Arch support is not implemented yet."
+    ui_error "Arch support is not implemented yet."
     exit 1
     ;;
   fedora)
-    echo "Fedora support is not implemented yet."
+    ui_error "Fedora support is not implemented yet."
     exit 1
     ;;
   macos)
-    echo "macOS support is not implemented yet."
+    ui_error "macOS support is not implemented yet."
     exit 1
     ;;
   *)
-    echo "Unsupported platform."
+    ui_error "Unsupported platform."
     exit 1
     ;;
 esac
 
-echo ""
 if ! ui_confirm "Proceed with bootstrap?"; then
-  echo "Aborted."
+  ui_info "Aborted."
   exit 0
 fi
 
 ensure_sudo_access
 
-step "Bootstrapping this machine"
+ui_section "Bootstrapping"
+
+# Steps 1 and 3 are local/config — use dot spinner
+# Step 2 is a download — use globe spinner
+export DOTFILES_SPINNER=dot
 run_named_script "[1/3] Installing bootstrap dependencies" "$INSTALL_DIR/bootstrap/linux-apt.sh"
+export DOTFILES_SPINNER=globe
 run_named_script "[2/3] Installing gum" "$INSTALL_DIR/tools/app-gum.sh"
+export DOTFILES_SPINNER=dot
 run_named_script "[3/3] Making dotfiles CLI available" "$INSTALL_DIR/tools/app-bin.sh"
 
-ok "Bootstrap complete"
-info "Use 'dotfiles install' for the full setup flow."
-info "Use 'dotfiles theme' or 'dotfiles update' later from the CLI."
-
+ui_banner_success "Bootstrap complete" "dotfiles CLI is ready"
+ui_info "Use 'dotfiles install' for the full setup flow."
+ui_info "Use 'dotfiles theme' or 'dotfiles update' later from the CLI."
 echo ""
+
 if ui_confirm "Launch the dotfiles installer now?"; then
   bash "$DOTFILES_CLI" install
 else
-  echo "Next steps:"
-  echo "  ~/.local/bin/dotfiles install"
+  ui_info "When ready, run:  ~/.local/bin/dotfiles install"
 fi

--- a/install/categories/base-setup.sh
+++ b/install/categories/base-setup.sh
@@ -20,6 +20,7 @@ fi
 ensure_sudo_access
 
 step "Creating XDG directories"
+export DOTFILES_SPINNER=dot
 for dir in \
   "$HOME/.config" \
   "$HOME/.local/bin" \
@@ -32,14 +33,18 @@ for dir in \
 done
 
 step "Installing base setup"
-run_named_script "[1/9] Stowing dotfiles CLI" "$install_dir/tools/app-bin.sh"
-run_named_script "[2/9] Applying bash config" "$install_dir/tools/app-bash.sh"
-run_named_script "[3/9] Installing git + config" "$install_dir/tools/app-git.sh"
-run_named_script "[4/9] Installing bat + config" "$install_dir/tools/app-bat.sh"
-run_named_script "[5/9] Installing eza" "$install_dir/tools/app-eza.sh"
-run_named_script "[6/9] Installing zoxide" "$install_dir/tools/app-zoxide.sh"
+export DOTFILES_SPINNER=dot
+run_named_script "[1/9] Stowing dotfiles CLI"      "$install_dir/tools/app-bin.sh"
+run_named_script "[2/9] Applying bash config"      "$install_dir/tools/app-bash.sh"
+export DOTFILES_SPINNER=moon
+run_named_script "[3/9] Installing git + config"   "$install_dir/tools/app-git.sh"
+run_named_script "[4/9] Installing bat + config"   "$install_dir/tools/app-bat.sh"
+run_named_script "[5/9] Installing eza"            "$install_dir/tools/app-eza.sh"
+run_named_script "[6/9] Installing zoxide"         "$install_dir/tools/app-zoxide.sh"
+export DOTFILES_SPINNER=globe
 run_named_script "[7/9] Installing starship + config" "$install_dir/tools/app-starship.sh"
-run_named_script "[8/9] Installing mise" "$install_dir/tools/app-mise.sh"
-run_named_script "[9/9] Installing zsh + config" "$install_dir/tools/app-zsh.sh"
+run_named_script "[8/9] Installing mise"           "$install_dir/tools/app-mise.sh"
+export DOTFILES_SPINNER=moon
+run_named_script "[9/9] Installing zsh + config"  "$install_dir/tools/app-zsh.sh"
 
-ok "Base setup complete"
+ui_banner_success "Base setup complete" "shell · git · bat · eza · zsh · starship · mise"

--- a/install/categories/coding-agents.sh
+++ b/install/categories/coding-agents.sh
@@ -8,7 +8,7 @@ install_dir="$(cd "$(dirname "$0")/.." && pwd)"
 # shellcheck disable=SC1091
 source "$install_dir/lib/common.sh"
 
-step "Installing coding agents"
+ui_section "Installing coding agents"
 
 failed=()
 install_agent() {
@@ -21,23 +21,59 @@ install_agent() {
   fi
 }
 
-install_agent "[1/6] Installing pi" "$install_dir/agents/app-pi.sh" pi
-install_agent "[2/6] Installing codex" "$install_dir/agents/app-codex.sh" codex
-install_agent "[3/6] Installing gemini" "$install_dir/agents/app-gemini.sh" gemini
-install_agent "[4/6] Installing claude" "$install_dir/agents/app-claude.sh" claude
-install_agent "[5/6] Installing copilot" "$install_dir/agents/app-copilot.sh" copilot
+export DOTFILES_SPINNER=globe
+install_agent "[1/6] Installing pi"       "$install_dir/agents/app-pi.sh"       pi
+install_agent "[2/6] Installing codex"    "$install_dir/agents/app-codex.sh"    codex
+install_agent "[3/6] Installing gemini"   "$install_dir/agents/app-gemini.sh"   gemini
+install_agent "[4/6] Installing claude"   "$install_dir/agents/app-claude.sh"   claude
+install_agent "[5/6] Installing copilot"  "$install_dir/agents/app-copilot.sh"  copilot
 install_agent "[6/6] Installing opencode" "$install_dir/agents/app-opencode.sh" opencode
 
 if [ "${#failed[@]}" -gt 0 ]; then
   echo ""
-  warn "Some coding agent installs failed: ${failed[*]}"
+  ui_warn "Some coding agent installs failed: ${failed[*]}"
 fi
 
+# ── Setup reminder panel ──────────────────────────────────────────────────────
+
 echo ""
-echo "Authentication/setup reminders:"
-echo "  - pi: run 'pi' and use /login or configure an API key"
-echo "  - claude: run 'claude' and follow the browser prompt"
-echo "  - copilot: run 'copilot' and use /login if needed"
-echo "  - gemini: run 'gemini' and sign in or set GEMINI_API_KEY"
-echo "  - codex: run 'codex' and sign in or set OPENAI_API_KEY"
-echo "  - opencode: run 'opencode' and use /connect or provider API keys"
+if command -v gum >/dev/null 2>&1; then
+  # Build the reminder text
+  heading="$(gum style --foreground "$UI_BLUE" --bold "  Agent Setup Reminders")"
+  divider="$(gum style --foreground "$UI_BORDER" "  ──────────────────────────────────────────")"
+
+  _agent_line() {
+    local name="$1" hint="$2"
+    printf '%s%-12s%s %s%s%s\n' \
+      "$_UI_ACCENT" "$name" "$_UI_RST" \
+      "$_UI_MUTED"  "$hint" "$_UI_RST"
+  }
+
+  reminders="$(
+    _agent_line "pi"       "run 'pi'       → /login or configure an API key"
+    _agent_line "claude"   "run 'claude'   → follow the browser prompt"
+    _agent_line "copilot"  "run 'copilot'  → /login if needed"
+    _agent_line "gemini"   "run 'gemini'   → sign in or set GEMINI_API_KEY"
+    _agent_line "codex"    "run 'codex'    → sign in or set OPENAI_API_KEY"
+    _agent_line "opencode" "run 'opencode' → /connect or set provider API keys"
+  )"
+
+  gum style \
+    --border rounded \
+    --border-foreground "$UI_BLUE" \
+    --padding "0 2" \
+    "$heading" \
+    "" \
+    "$divider" \
+    "" \
+    "$reminders"
+else
+  printf '\nAuthentication/setup reminders:\n'
+  printf '  pi       · run '"'"'pi'"'"' and use /login or configure an API key\n'
+  printf '  claude   · run '"'"'claude'"'"' and follow the browser prompt\n'
+  printf '  copilot  · run '"'"'copilot'"'"' and use /login if needed\n'
+  printf '  gemini   · run '"'"'gemini'"'"' and sign in or set GEMINI_API_KEY\n'
+  printf '  codex    · run '"'"'codex'"'"' and sign in or set OPENAI_API_KEY\n'
+  printf '  opencode · run '"'"'opencode'"'"' and use /connect or set provider API keys\n'
+fi
+echo ""

--- a/install/categories/install-everything.sh
+++ b/install/categories/install-everything.sh
@@ -9,10 +9,11 @@ dotfiles_dir="$(cd "$install_dir/.." && pwd)"
 # shellcheck disable=SC1091
 source "$install_dir/lib/common.sh"
 
-step "Running full setup"
-run_named_script "[1/4] Base setup" "$install_dir/categories/base-setup.sh"
-run_named_script "[2/4] Terminal tools" "$install_dir/categories/terminal-tools.sh"
-run_named_script "[3/4] Coding agents" "$install_dir/categories/coding-agents.sh"
+ui_section "Running full setup"
+
+run_named_script "[1/4] Base setup"            "$install_dir/categories/base-setup.sh"
+run_named_script "[2/4] Terminal tools"        "$install_dir/categories/terminal-tools.sh"
+run_named_script "[3/4] Coding agents"         "$install_dir/categories/coding-agents.sh"
 run_named_script "[4/4] Applying default theme" "$dotfiles_dir/scripts/theme.sh" catppuccin
 
-ok "Install everything complete"
+ui_banner_success "Install Everything complete" "4 categories · base · terminal · agents · theme"

--- a/install/categories/terminal-tools.sh
+++ b/install/categories/terminal-tools.sh
@@ -10,19 +10,22 @@ source "$install_dir/lib/common.sh"
 
 ensure_sudo_access
 
+export DOTFILES_SPINNER=moon
 step "Installing terminal tools"
-run_named_script "[1/13] Installing alacritty config" "$install_dir/tools/app-alacritty.sh"
-run_named_script "[2/13] Installing btop + config" "$install_dir/tools/app-btop.sh"
-run_named_script "[3/13] Installing fastfetch + config" "$install_dir/tools/app-fastfetch.sh"
-run_named_script "[4/13] Installing fd" "$install_dir/tools/app-fd.sh"
-run_named_script "[5/13] Installing fzf + config" "$install_dir/tools/app-fzf.sh"
-run_named_script "[6/13] Installing GitHub CLI" "$install_dir/tools/app-gh.sh"
-run_named_script "[7/13] Installing lazygit" "$install_dir/tools/app-lazygit.sh"
-run_named_script "[8/13] Installing lazydocker" "$install_dir/tools/app-lazydocker.sh"
-run_named_script "[9/13] Installing neovim + config" "$install_dir/tools/app-neovim.sh"
-run_named_script "[10/13] Installing ripgrep + config" "$install_dir/tools/app-ripgrep.sh"
-run_named_script "[11/13] Installing tmux + config" "$install_dir/tools/app-tmux.sh"
-run_named_script "[12/13] Installing vim + config" "$install_dir/tools/app-vim.sh"
-run_named_script "[13/13] Installing zellij + config" "$install_dir/tools/app-zellij.sh"
+run_named_script "[1/13] Installing alacritty config"    "$install_dir/tools/app-alacritty.sh"
+run_named_script "[2/13] Installing btop + config"       "$install_dir/tools/app-btop.sh"
+run_named_script "[3/13] Installing fastfetch + config"  "$install_dir/tools/app-fastfetch.sh"
+run_named_script "[4/13] Installing fd"                  "$install_dir/tools/app-fd.sh"
+export DOTFILES_SPINNER=globe
+run_named_script "[5/13] Installing fzf + config"        "$install_dir/tools/app-fzf.sh"
+run_named_script "[6/13] Installing GitHub CLI"          "$install_dir/tools/app-gh.sh"
+run_named_script "[7/13] Installing lazygit"             "$install_dir/tools/app-lazygit.sh"
+run_named_script "[8/13] Installing lazydocker"          "$install_dir/tools/app-lazydocker.sh"
+run_named_script "[9/13] Installing neovim + config"     "$install_dir/tools/app-neovim.sh"
+export DOTFILES_SPINNER=moon
+run_named_script "[10/13] Installing ripgrep + config"   "$install_dir/tools/app-ripgrep.sh"
+run_named_script "[11/13] Installing tmux + config"      "$install_dir/tools/app-tmux.sh"
+run_named_script "[12/13] Installing vim + config"       "$install_dir/tools/app-vim.sh"
+run_named_script "[13/13] Installing zellij + config"    "$install_dir/tools/app-zellij.sh"
 
-ok "Terminal tools complete"
+ui_banner_success "Terminal tools complete" "13 tools installed and configured"

--- a/install/languages/select.sh
+++ b/install/languages/select.sh
@@ -6,8 +6,7 @@ base_dir="$(cd "$(dirname "$0")" && pwd)"
 
 # shellcheck disable=SC1091
 source "$install_dir/lib/common.sh"
-# shellcheck disable=SC1091
-source "$install_dir/lib/ui.sh"
+# ui.sh is auto-sourced by common.sh
 
 choices=("Node.js" "Bun" "Java" "Python" "Go" "Rust")
 
@@ -42,8 +41,8 @@ selected=()
 if [ "$#" -gt 0 ]; then
   for arg in "$@"; do
     normalized="$(normalize_language "$arg")" || {
-      echo "Unknown language: $arg" >&2
-      echo "Available: node bun java python go rust" >&2
+      ui_error "Unknown language: $arg"
+      ui_info "Available: node bun java python go rust"
       exit 1
     }
 
@@ -68,8 +67,11 @@ mapfile -t selected < <(printf '%s\n' "${selected[@]}" | awk '!seen[$0]++')
 total="${#selected[@]}"
 index=0
 
+export DOTFILES_SPINNER=globe
 step "Installing programming languages"
 for choice in "${selected[@]}"; do
   index=$((index + 1))
   run_language "$choice" "[$index/$total] Installing $choice"
 done
+
+ui_banner_success "Languages installed" "$(printf '%s' "${selected[*]}")"

--- a/install/lib/common.sh
+++ b/install/lib/common.sh
@@ -3,25 +3,22 @@
 
 set -euo pipefail
 
+# Pull in UI helpers (colour palette, gum wrappers, status printers).
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ui.sh"
+
 command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
-step() {
-  printf "\n==> %s\n" "$*"
-}
+# ── Status primitives — delegate to ui.sh ─────────────────────────────────────
 
-info() {
-  printf "  %s\n" "$*"
-}
+step()  { ui_section "$@"; }
+ok()    { ui_ok "$@"; }
+warn()  { ui_warn "$@"; }
+info()  { ui_info "$@"; }
 
-ok() {
-  printf "  ✓ %s\n" "$*"
-}
-
-warn() {
-  printf "  ! %s\n" "$*"
-}
+# ── Directory helpers ─────────────────────────────────────────────────────────
 
 ensure_dir() {
   [ -d "$1" ] || mkdir -p "$1"
@@ -31,8 +28,7 @@ ensure_sudo_access() {
   if [ "$(id -u)" -eq 0 ]; then
     return 0
   fi
-
-  info "Sudo access is required for the next step."
+  ui_info "Sudo access is required for the next step."
   sudo -v
 }
 
@@ -40,11 +36,11 @@ apt_install_if_missing() {
   local package
   for package in "$@"; do
     if dpkg -s "$package" >/dev/null 2>&1; then
-      ok "$package already installed"
+      ui_ok "$package already installed"
     else
-      info "Installing $package..."
+      ui_info "Installing $package..."
       sudo apt install -y "$package"
-      ok "$package installed"
+      ui_ok "$package installed"
     fi
   done
 }
@@ -55,12 +51,19 @@ repo_root() {
   cd "$(dirname "$script_path")/../.." && pwd
 }
 
+# ── Task runner ───────────────────────────────────────────────────────────────
+# Wraps a command in a gum spinner while it runs.
+# Spinner type is controlled by DOTFILES_SPINNER (default: moon).
+# Set DOTFILES_SPINNER=globe for network-heavy operations,
+#     DOTFILES_SPINNER=dot  for quick/local operations.
+
 run_task() {
   local title="$1"
   shift
+  local spinner="${DOTFILES_SPINNER:-moon}"
 
   if command_exists gum; then
-    gum spin --spinner dot --title "$title" --show-error -- "$@"
+    gum spin --spinner "$spinner" --title "$title" --show-error -- "$@"
   else
     local log_file status
     log_file="$(mktemp)"
@@ -70,7 +73,7 @@ run_task() {
     fi
 
     status=$?
-    warn "$title failed"
+    ui_warn "$title failed"
     cat "$log_file" >&2
     rm -f "$log_file"
     return "$status"
@@ -82,7 +85,7 @@ run_script() {
   shift || true
 
   if [ ! -f "$script" ]; then
-    warn "Missing script: $script"
+    ui_warn "Missing script: $script"
     return 1
   fi
 
@@ -95,10 +98,10 @@ run_named_script() {
   shift 2 || true
 
   if [ ! -f "$script" ]; then
-    warn "Missing script: $script"
+    ui_warn "Missing script: $script"
     return 1
   fi
 
   run_task "$title" bash "$script" "$@"
-  ok "$title"
+  ui_ok "$title"
 }

--- a/install/lib/ui.sh
+++ b/install/lib/ui.sh
@@ -1,19 +1,227 @@
 #!/usr/bin/env bash
-# UI helpers with gum fallback
+# UI helpers — Catppuccin Mocha themed, gum-powered with plain-text fallbacks
+# Sourced by common.sh and any script that needs interactive UI.
+
+# Guard against double-sourcing
+[[ -n "${_UI_SH_LOADED:-}" ]] && return 0
+readonly _UI_SH_LOADED=1
+
+# ── Palette (hex — used for GUM_* env vars) ───────────────────────────────────
+
+UI_ACCENT="#cba6f7"  # mauve    — cursor, selected, accent borders
+UI_BLUE="#89b4fa"    # blue     — section headings, sub-headers
+UI_GREEN="#a6e3a1"   # green    — success, ok
+UI_YELLOW="#f9e2af"  # yellow   — warnings
+UI_RED="#f38ba8"     # red      — errors, failures
+UI_MUTED="#6c7086"   # overlay0 — secondary text, hints
+UI_BORDER="#585b70"  # surface2 — panel outlines
+
+# ANSI 24-bit sequences — precomputed for zero-subprocess status messages
+# Format: \e[38;2;R;G;Bm (fg)   \e[48;2;R;G;Bm (bg)
+_UI_RST=$'\e[0m'
+_UI_BOLD=$'\e[1m'
+_UI_DIM=$'\e[2m'
+_UI_ITALIC=$'\e[3m'
+_UI_ACCENT=$'\e[38;2;203;166;247m'  # #cba6f7
+_UI_BLUE=$'\e[38;2;137;180;250m'    # #89b4fa
+_UI_GREEN=$'\e[38;2;166;227;161m'   # #a6e3a1
+_UI_YELLOW=$'\e[38;2;249;226;175m'  # #f9e2af
+_UI_RED=$'\e[38;2;243;139;168m'     # #f38ba8
+_UI_MUTED=$'\e[38;2;108;112;134m'   # #6c7086
+_UI_BORDER=$'\e[38;2;88;91;112m'    # #585b70
+
+# ── GUM environment defaults ──────────────────────────────────────────────────
+# Set once here — every downstream gum call inherits the palette automatically.
+
+export GUM_CHOOSE_CURSOR_FOREGROUND="$UI_ACCENT"
+export GUM_CHOOSE_HEADER_FOREGROUND="$UI_BLUE"
+export GUM_CHOOSE_SELECTED_FOREGROUND="$UI_ACCENT"
+export GUM_CHOOSE_CURSOR_PREFIX="▸ "
+export GUM_CHOOSE_SELECTED_PREFIX="◆ "
+export GUM_CHOOSE_UNSELECTED_PREFIX="◇ "
+export GUM_CONFIRM_PROMPT_FOREGROUND="$UI_ACCENT"
+export GUM_CONFIRM_SELECTED_BACKGROUND="$UI_ACCENT"
+export GUM_CONFIRM_SELECTED_FOREGROUND="#1e1e2e"
+export GUM_CONFIRM_UNSELECTED_BACKGROUND="#313244"
+export GUM_CONFIRM_UNSELECTED_FOREGROUND="#cdd6f4"
+export GUM_SPIN_SPINNER_FOREGROUND="$UI_ACCENT"
+export GUM_INPUT_CURSOR_FOREGROUND="$UI_ACCENT"
+export GUM_INPUT_PROMPT_FOREGROUND="$UI_BLUE"
+# Preserve nested ANSI codes when passed as args to gum style
+export GUM_STYLE_STRIP_ANSI=false
+
+# ── Header ────────────────────────────────────────────────────────────────────
 
 ui_header() {
-  cat << 'EOF'
+  if command -v gum >/dev/null 2>&1; then
+    echo ""
+    gum style \
+      --border double \
+      --border-foreground "$UI_ACCENT" \
+      --align center \
+      --padding "1 6" \
+      "$(gum style --foreground "$UI_ACCENT" --bold 'd o t f i l e s')" \
+      "$(gum style --foreground "$UI_MUTED" --italic 'your machine, your rules')"
+    echo ""
+  else
+    cat << 'EOF'
 
   ╭─────────────────────────────────────╮
   │         d o t f i l e s             │
   ╰─────────────────────────────────────╯
 
 EOF
+  fi
 }
+
+# ── Section divider ───────────────────────────────────────────────────────────
+
+ui_section() {
+  echo ""
+  if command -v gum >/dev/null 2>&1; then
+    gum style --foreground "$UI_BLUE" --bold "── $* ──────────────────────────────────────"
+  else
+    printf '==> %s\n' "$*"
+  fi
+  echo ""
+}
+
+# ── Status messages ───────────────────────────────────────────────────────────
+# Raw ANSI — no subprocess overhead, safe to call many times per install.
+
+ui_ok() {
+  printf '%s  ✓  %s%s\n' "$_UI_GREEN" "$*" "$_UI_RST"
+}
+
+ui_warn() {
+  printf '%s  ⚠  %s%s\n' "$_UI_YELLOW" "$*" "$_UI_RST"
+}
+
+ui_error() {
+  printf '%s  ✗  %s%s\n' "$_UI_RED" "$*" "$_UI_RST" >&2
+}
+
+ui_info() {
+  printf '%s     %s%s\n' "$_UI_MUTED" "$*" "$_UI_RST"
+}
+
+# ── Structured log (gum log) ──────────────────────────────────────────────────
+# Levelled output for scripts that emit multiple structured messages
+# (update, ai-skills). Level: debug | info | warn | error
+
+ui_log() {
+  local level="${1:-info}"
+  shift
+  if command -v gum >/dev/null 2>&1; then
+    gum log --level "$level" -- "$@"
+  else
+    printf '[%s] %s\n' "$level" "$*"
+  fi
+}
+
+# ── Completion banner ─────────────────────────────────────────────────────────
+
+ui_banner_success() {
+  local title="$1"
+  local subtitle="${2:-}"
+  echo ""
+  if command -v gum >/dev/null 2>&1; then
+    if [ -n "$subtitle" ]; then
+      gum style \
+        --border rounded \
+        --border-foreground "$UI_GREEN" \
+        --padding "0 2" \
+        --align center \
+        "$(gum style --foreground "$UI_GREEN" --bold "✓  $title")" \
+        "$(gum style --foreground "$UI_MUTED" --italic "$subtitle")"
+    else
+      gum style \
+        --border rounded \
+        --border-foreground "$UI_GREEN" \
+        --padding "0 2" \
+        --align center \
+        "$(gum style --foreground "$UI_GREEN" --bold "✓  $title")"
+    fi
+  else
+    printf '  ✓  %s\n' "$title"
+    [ -n "$subtitle" ] && printf '     %s\n' "$subtitle"
+  fi
+  echo ""
+}
+
+# ── Swatch helpers ────────────────────────────────────────────────────────────
+
+# Output a 3-wide coloured block using ANSI 24-bit background.
+# Arg: hex colour string (with or without leading #)
+ui_color_block() {
+  local hex="${1#'#'}"
+  printf '\033[48;2;%d;%d;%dm   \033[0m' \
+    $((16#${hex:0:2})) \
+    $((16#${hex:2:2})) \
+    $((16#${hex:4:2}))
+}
+
+# Print one theme swatch row: coloured name + 5 colour blocks.
+# Args: name accent c1 c2 c3 c4 c5
+ui_swatch_row() {
+  local name="$1" accent="$2"
+  local c1="$3" c2="$4" c3="$5" c4="$6" c5="$7"
+  local padded
+  padded="$(printf '%-14s' "$name")"
+  local hex="${accent#'#'}"
+  printf '  \033[38;2;%d;%d;%dm%s\033[0m %s%s%s%s%s\n' \
+    $((16#${hex:0:2})) $((16#${hex:2:2})) $((16#${hex:4:2})) \
+    "$padded" \
+    "$(ui_color_block "$c1")" \
+    "$(ui_color_block "$c2")" \
+    "$(ui_color_block "$c3")" \
+    "$(ui_color_block "$c4")" \
+    "$(ui_color_block "$c5")"
+}
+
+# Interactive theme picker with live swatch preview above the selection list.
+# Prints the chosen theme name to stdout, or returns empty on cancel.
+ui_swatch_picker() {
+  if ! command -v gum >/dev/null 2>&1; then
+    printf '  Available themes:\n'
+    printf '    - %s\n' \
+      "Catppuccin" "Tokyo Night" "Nord" "Gruvbox" "Everforest" \
+      "Kanagawa" "Rose Pine" "Matte Black" "Osaka Jade" "Ristretto"
+    return
+  fi
+
+  echo ""
+  printf '%s%s  Theme Palette Preview%s\n' "$_UI_BOLD" "$_UI_BLUE" "$_UI_RST"
+  printf '%s  ──────────────────────────────────────%s\n' "$_UI_BORDER" "$_UI_RST"
+  echo ""
+
+  # Columns: name | accent | bg | red | green | yellow | accent2
+  ui_swatch_row "Catppuccin"  "#cba6f7" "#24273a" "#f38ba8" "#a6e3a1" "#f9e2af" "#89b4fa"
+  ui_swatch_row "Tokyo Night" "#7aa2f7" "#1a1b26" "#f7768e" "#9ece6a" "#e0af68" "#ad8ee6"
+  ui_swatch_row "Nord"        "#81a1c1" "#2e3440" "#bf616a" "#a3be8c" "#ebcb8b" "#b48ead"
+  ui_swatch_row "Gruvbox"     "#d8a657" "#282828" "#ea6962" "#a9b665" "#d8a657" "#7daea3"
+  ui_swatch_row "Everforest"  "#a7c080" "#2d353b" "#e67e80" "#a7c080" "#dbbc7f" "#7fbbb3"
+  ui_swatch_row "Kanagawa"    "#7e9cd8" "#1f1f28" "#c34043" "#76946a" "#c0a36e" "#957fb8"
+  ui_swatch_row "Rose Pine"   "#907aa9" "#faf4ed" "#d7827e" "#56949f" "#ea9d34" "#286983"
+  ui_swatch_row "Matte Black" "#bebebe" "#121212" "#D35F5F" "#FFC107" "#e68e0d" "#bebebe"
+  ui_swatch_row "Osaka Jade"  "#549e6a" "#111c18" "#FF5345" "#549e6a" "#459451" "#2DD5B7"
+  ui_swatch_row "Ristretto"   "#fd6883" "#2c2525" "#fd6883" "#adda78" "#f9cc6c" "#a8a9eb"
+
+  echo ""
+  printf '%s  ──────────────────────────────────────%s\n' "$_UI_BORDER" "$_UI_RST"
+  echo ""
+
+  gum choose \
+    "Catppuccin" "Tokyo Night" "Nord" "Gruvbox" "Everforest" \
+    "Kanagawa" "Rose Pine" "Matte Black" "Osaka Jade" "Ristretto" \
+    --header "  Select a theme" \
+    --height 12
+}
+
+# ── Interactive helpers ───────────────────────────────────────────────────────
 
 ui_confirm() {
   local prompt="$1"
-
   if command -v gum >/dev/null 2>&1; then
     gum confirm "$prompt"
   else
@@ -25,11 +233,10 @@ ui_confirm() {
 ui_choose_one() {
   local header="$1"
   shift
-
   if command -v gum >/dev/null 2>&1; then
     gum choose "$@" --header "$header"
   else
-    printf "%s\n" "$header" >&2
+    printf '%s\n' "$header" >&2
     printf '%s\n' "$@" >&2
     printf '%s\n' "$1"
   fi
@@ -38,7 +245,6 @@ ui_choose_one() {
 ui_choose_many() {
   local header="$1"
   shift
-
   if command -v gum >/dev/null 2>&1; then
     gum choose "$@" --no-limit --header "$header"
   else

--- a/scripts/ai-skills.sh
+++ b/scripts/ai-skills.sh
@@ -4,100 +4,122 @@
 
 set -e
 
-# Array of skills to always have installed
+SELF="$(readlink -f "$0")"
+DOTFILES_DIR="$(cd "$(dirname "$SELF")/.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$DOTFILES_DIR/install/lib/ui.sh"
+
+# ── Skills list ───────────────────────────────────────────────────────────────
 # Format: "owner/repo"
+
 SKILLS=(
   # Personal skills
   "abijith-suresh/skills"
-  
+
   # Essential community skills
   "vercel-labs/agent-skills"
   "anthropics/skills"
   "vercel-labs/agent-browser"
 )
 
+# ── Commands ──────────────────────────────────────────────────────────────────
+
 show_help() {
-  cat << EOF
+  if command -v gum >/dev/null 2>&1; then
+    gum style \
+      --border rounded \
+      --border-foreground "$UI_BLUE" \
+      --padding "0 2" \
+      "$(gum style --foreground "$UI_BLUE" --bold "  AI Skills Manager")" \
+      "" \
+      "$(printf '%s  Usage: %s{install|update|status|list|sync}%s' "$_UI_MUTED" "$_UI_ACCENT" "$_UI_RST")" \
+      "" \
+      "$(printf '%s  install%s   Install/update all tracked skills' "$_UI_ACCENT" "$_UI_RST")" \
+      "$(printf '%s  update%s    Update all installed skills to latest' "$_UI_ACCENT" "$_UI_RST")" \
+      "$(printf '%s  status%s    Show installed vs tracked' "$_UI_ACCENT" "$_UI_RST")" \
+      "$(printf '%s  list%s      Print the tracked skills list' "$_UI_ACCENT" "$_UI_RST")" \
+      "$(printf '%s  sync%s      Install missing, update existing' "$_UI_ACCENT" "$_UI_RST")"
+    echo ""
+  else
+    cat << EOF
 AI Skills Manager
 
-Usage: $(basename "$0") {install|update|status|list}
+Usage: $(basename "$0") {install|update|status|list|sync}
 
-Commands:
-  install    Install/update all skills in the hardcoded list
-  update     Update all installed skills to latest
-  status     Check which skills are installed
-  list       Show the hardcoded skills list
-  sync       Install missing skills, update existing ones
-
-Examples:
-  $(basename "$0") install    # First time setup
-  $(basename "$0") sync       # Daily use - ensures all skills present
+  install   Install/update all skills in the tracked list
+  update    Update all installed skills to latest
+  status    Check which skills are installed
+  list      Show the tracked skills list
+  sync      Install missing skills, update existing ones
 EOF
+  fi
 }
 
 install_skills() {
-  echo "Installing skills..."
+  ui_section "Installing skills"
   for skill in "${SKILLS[@]}"; do
-    echo "  → $skill"
+    ui_log info "Installing $skill"
     bunx skills add "$skill" --yes --global
+    ui_ok "$skill"
   done
-  echo "✓ All skills installed"
+  ui_banner_success "All skills installed"
 }
 
 update_skills() {
-  echo "Updating all skills..."
-  bunx skills update
-  echo "✓ Skills updated"
+  ui_section "Updating skills"
+  if command -v gum >/dev/null 2>&1; then
+    gum spin --spinner globe --title "Updating all skills..." --show-error -- \
+      bunx skills update
+  else
+    bunx skills update
+  fi
+  ui_banner_success "Skills updated"
 }
 
 show_status() {
-  echo "Installed skills:"
-  bunx skills list -g || echo "  (no skills installed)"
+  ui_section "Skills Status"
+
+  ui_log info "Installed skills:"
+  bunx skills list -g || ui_info "(no skills installed)"
+
   echo ""
-  echo "Tracked in script:"
+  ui_log info "Tracked in script:"
   for skill in "${SKILLS[@]}"; do
-    echo "  • $skill"
+    printf '%s     • %s%s\n' "$_UI_MUTED" "$skill" "$_UI_RST"
   done
 }
 
 show_list() {
-  echo "Skills tracked in this script:"
+  ui_section "Tracked Skills"
   for skill in "${SKILLS[@]}"; do
-    echo "  • $skill"
+    printf '%s     • %s%s\n' "$_UI_MUTED" "$skill" "$_UI_RST"
   done
 }
 
 sync_skills() {
-  echo "Syncing skills..."
-  # This installs missing ones and updates existing
+  ui_section "Syncing skills"
   for skill in "${SKILLS[@]}"; do
-    echo "  → Ensuring: $skill"
-    bunx skills add "$skill" --yes --global 2>/dev/null || bunx skills update "$skill" 2>/dev/null || true
+    ui_log info "Ensuring $skill"
+    bunx skills add "$skill" --yes --global 2>/dev/null \
+      || bunx skills update "$skill" 2>/dev/null \
+      || true
+    ui_ok "$skill"
   done
-  echo "✓ Sync complete"
+  ui_banner_success "Sync complete"
 }
 
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+
 case "${1:-}" in
-  install)
-    install_skills
-    ;;
-  update)
-    update_skills
-    ;;
-  status)
-    show_status
-    ;;
-  list)
-    show_list
-    ;;
-  sync)
-    sync_skills
-    ;;
-  help|--help|-h|"")
-    show_help
-    ;;
+  install)         install_skills ;;
+  update)          update_skills ;;
+  status)          show_status ;;
+  list)            show_list ;;
+  sync)            sync_skills ;;
+  help|--help|-h|"") show_help ;;
   *)
-    echo "Unknown command: $1"
+    ui_error "Unknown command: $1"
     show_help
     exit 1
     ;;

--- a/scripts/clean-backups.sh
+++ b/scripts/clean-backups.sh
@@ -24,20 +24,10 @@ auto_yes=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run)
-      dry_run=1
-      ;;
-    --yes)
-      auto_yes=1
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      usage >&2
-      exit 1
-      ;;
+    --dry-run) dry_run=1 ;;
+    --yes)     auto_yes=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *)         usage >&2; exit 1 ;;
   esac
   shift
 done
@@ -59,29 +49,36 @@ while IFS= read -r -d '' target; do
   if [ -d "$backup_dir" ]; then
     while IFS= read -r numbered_backup; do
       backups+=("$numbered_backup")
-    done < <(find "$backup_dir" -maxdepth 1 \( -type f -o -type l -o -type d \) -name "$backup_name.backup.*" | sort)
+    done < <(find "$backup_dir" -maxdepth 1 \( -type f -o -type l -o -type d \) \
+      -name "$backup_name.backup.*" | sort)
   fi
 done < <(list_target_paths "$DOTFILES_DIR" "${packages[@]}")
 
 if [ "${#backups[@]}" -eq 0 ]; then
-  echo "No dotfiles backups found."
+  ui_info "No dotfiles backups found."
   exit 0
 fi
 
 mapfile -t backups < <(printf '%s\n' "${backups[@]}" | awk '!seen[$0]++')
 
 if [ "$dry_run" -eq 1 ]; then
-  echo "Would remove the following backups:"
-  printf '  %s\n' "${backups[@]}"
+  ui_warn "Dry run — would remove the following backups:"
+  for b in "${backups[@]}"; do
+    printf '%s     %s%s\n' "$_UI_MUTED" "$b" "$_UI_RST"
+  done
   exit 0
 fi
 
+ui_section "Clean Backups"
+printf '%s  The following backups will be removed:%s\n' "$_UI_MUTED" "$_UI_RST"
+for b in "${backups[@]}"; do
+  printf '%s     %s%s\n' "$_UI_MUTED" "$b" "$_UI_RST"
+done
+echo ""
+
 if [ "$auto_yes" -ne 1 ]; then
-  echo "The following backups will be removed:"
-  printf '  %s\n' "${backups[@]}"
-  echo ""
   if ! ui_confirm "Delete these backup files?"; then
-    echo "Aborted."
+    ui_info "Aborted."
     exit 0
   fi
 fi
@@ -92,4 +89,4 @@ for backup in "${backups[@]}"; do
   count=$((count + 1))
 done
 
-echo "Removed $count backup(s)."
+ui_banner_success "Removed $count backup(s)"

--- a/scripts/theme.sh
+++ b/scripts/theme.sh
@@ -22,7 +22,7 @@ to_dir_name() {
 
 restow_theme_packages() {
   if ! command -v stow >/dev/null 2>&1; then
-    echo "stow not found — updated repo files but did not restow live config"
+    ui_warn "stow not found — updated repo files but did not restow live config"
     return 0
   fi
 
@@ -30,11 +30,11 @@ restow_theme_packages() {
 
   (
     cd "$DOTFILES_DIR/configs"
-    stow_restow starship
-    stow_restow nvim
-    stow_restow btop
-    stow_restow zellij
-    stow_restow alacritty
+    stow_restow starship && ui_ok "Stowed starship"
+    stow_restow nvim     && ui_ok "Stowed nvim"
+    stow_restow btop     && ui_ok "Stowed btop"
+    stow_restow zellij   && ui_ok "Stowed zellij"
+    stow_restow alacritty && ui_ok "Stowed alacritty"
   )
 }
 
@@ -60,53 +60,53 @@ apply_theme() {
   local theme_dir="$THEMES_DIR/$theme_name"
 
   if [ ! -d "$theme_dir" ]; then
-    echo "Theme not found: $theme_name"
+    ui_error "Theme not found: $theme_name"
     return 1
   fi
 
+  ui_section "Applying theme: $theme_name"
+
   echo "$theme_name" > "$CURRENT_THEME_FILE"
+  ui_ok "Updated themes/current-theme"
 
   # Starship
   cp "$theme_dir/starship.toml" "$DOTFILES_DIR/configs/starship/.config/starship.toml"
+  ui_ok "starship.toml"
 
   # Neovim
   mkdir -p "$DOTFILES_DIR/configs/nvim/.config/nvim/lua/plugins"
   cp "$theme_dir/neovim.lua" "$DOTFILES_DIR/configs/nvim/.config/nvim/lua/plugins/theme.lua"
+  ui_ok "nvim theme.lua"
 
   # btop
   mkdir -p "$DOTFILES_DIR/configs/btop/.config/btop/themes"
   cp "$theme_dir/btop.theme" "$DOTFILES_DIR/configs/btop/.config/btop/themes/current.theme"
+  ui_ok "btop current.theme"
 
   # Zellij
   mkdir -p "$DOTFILES_DIR/configs/zellij/.config/zellij/themes"
   render_zellij_theme "$theme_dir/zellij.kdl" "$DOTFILES_DIR/configs/zellij/.config/zellij/themes/current.kdl"
+  ui_ok "zellij current.kdl"
 
   # Alacritty
   mkdir -p "$DOTFILES_DIR/configs/alacritty/.config/alacritty"
   cp "$theme_dir/alacritty.toml" "$DOTFILES_DIR/configs/alacritty/.config/alacritty/theme.toml"
+  ui_ok "alacritty theme.toml"
 
+  ui_section "Restowing packages"
   restow_theme_packages
 
-  echo "Applied theme: $theme_name"
-  echo "Repo-backed theme state updated in configs/ and themes/current-theme"
+  ui_banner_success "Theme applied: $theme_name" "configs updated · packages restowed"
 }
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
 
 if [ -n "${1:-}" ]; then
   apply_theme "$(to_dir_name "$1")"
   exit 0
 fi
 
-if ! command -v gum >/dev/null 2>&1; then
-  echo "gum is required for interactive theme selection"
-  echo "Available themes:"
-  for name in "${THEME_NAMES[@]}"; do
-    echo "  - $(to_dir_name "$name")"
-  done
-  echo ""
-  echo "Backups created during theme conflict handling use the suffix '.backup'."
-  exit 1
-fi
-
-selected=$(gum choose "${THEME_NAMES[@]}" --header "Choose your theme")
+# Interactive: show swatch picker, then apply
+selected="$(ui_swatch_picker)"
 [ -z "$selected" ] && exit 0
 apply_theme "$(to_dir_name "$selected")"


### PR DESCRIPTION
## Summary

Introduces a full Catppuccin Mocha-themed UI system for the dotfiles CLI and all install/maintenance scripts.

### Commits

1. **`feat(ui): add Catppuccin-themed UI system with swatch picker`**
   - Rewrites `install/lib/ui.sh` with a Catppuccin Mocha color palette
   - Adds ANSI 24-bit color sequences for zero-subprocess status messages
   - Sets `GUM_*` environment defaults for consistent gum theming
   - New primitives: `ui_ok`, `ui_warn`, `ui_error`, `ui_info`, `ui_section`, `ui_log`, `ui_banner_success`
   - New swatch helpers: `ui_color_block`, `ui_swatch_row`, `ui_swatch_picker` for interactive theme selection with live color preview

2. **`refactor: migrate all scripts to themed UI primitives`**
   - Replaces raw `echo`/`step()`/`ok()`/`warn()`/`info()` calls with `ui_*` equivalents across all scripts
   - Adds contextual spinner types via `DOTFILES_SPINNER` (`dot` for local, `moon` for general, `globe` for network)
   - Enriches gum menus with descriptive subtitles
   - Adds styled agent setup reminder panel in `coding-agents.sh`
   - Adds completion banners with subtitles to all category installers
   - Removes duplicate `source ui.sh` calls (now auto-sourced by `common.sh`)

3. **`feat(git): enable forceWithLease and auto-prune`**
   - `push.forceWithLease = true` — safer force pushes
   - `fetch.prune = true` — auto-prune deleted remote branches