### PR TITLE
refactor(zsh): remove zinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/abijith-suresh/dotfiles.git ~/.dotfiles
 ## What It Does
 
 - Installs terminal tools, TUIs, coding agents, language runtimes, and editor tooling I use.
-- Installs `zsh`, Zinit, Starship, tmux plugins, Vim Catppuccin, and Neovim config.
+- Installs `zsh`, explicit zsh plugins, Starship, tmux plugins, Vim Catppuccin, and Neovim config.
 - Stows tracked config packages from `configs/`.
 - Backs up unmanaged config conflicts next to the original file before stowing repo config.
 

--- a/configs/fzf/.config/fzf/fzf.zsh
+++ b/configs/fzf/.config/fzf/fzf.zsh
@@ -5,14 +5,22 @@
 source <(fzf --zsh)
 
 # Use ripgrep for file finding (respects .gitignore, finds hidden files)
-export FZF_DEFAULT_COMMAND='rg --files --hidden --follow --glob "!.git"'
+if command -v rg >/dev/null 2>&1; then
+  export FZF_DEFAULT_COMMAND='rg --files --hidden --follow --glob "!.git"'
+fi
 
 # Official Catppuccin Mocha palette from catppuccin/fzf
-source "${XDG_CONFIG_HOME:-$HOME/.config}/fzf/themes/catppuccin-mocha.sh"
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/fzf/themes/catppuccin-mocha.sh" ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/fzf/themes/catppuccin-mocha.sh"
+fi
 export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --height 40% --layout=reverse --border"
 
 # CTRL-T: file picker with bat preview
-export FZF_CTRL_T_OPTS='--preview "bat --color=always --style=numbers {}"'
+if command -v bat >/dev/null 2>&1; then
+  export FZF_CTRL_T_OPTS='--preview "bat --color=always --style=numbers {}"'
+fi
 
 # ALT-C: directory picker with eza tree preview
-export FZF_ALT_C_OPTS='--preview "eza --tree --icons {}"'
+if command -v eza >/dev/null 2>&1; then
+  export FZF_ALT_C_OPTS='--preview "eza --tree --icons {}"'
+fi

--- a/configs/tmux/.config/tmux/tmux.conf
+++ b/configs/tmux/.config/tmux/tmux.conf
@@ -1,9 +1,6 @@
 # ~/.config/tmux/tmux.conf
 # tmux configuration with TPM plugins and Catppuccin Mocha theme
 
-# Use zsh as default
-set -g default-shell /bin/zsh
-
 # Enable 256-color and true-color (24-bit) support in tmux
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",*:Tc"

--- a/configs/zsh/.config/zsh/.zsh_aliases
+++ b/configs/zsh/.config/zsh/.zsh_aliases
@@ -4,15 +4,20 @@
 # ============================
 
 # --- File Listing (eza) ---
-alias ls='eza --icons --group-directories-first'
-alias ll='eza -lh --icons --git --group-directories-first'
-alias la='eza -lah --icons --git --group-directories-first'
-alias lt='eza --tree --icons --level=2 --long --git'
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --icons --group-directories-first'
+  alias ll='eza -lh --icons --git --group-directories-first'
+  alias la='eza -lah --icons --git --group-directories-first'
+  alias lt='eza --tree --icons --level=2 --long --git'
+else
+  alias ll='ls -lh'
+  alias la='ls -lah'
+fi
 
 # --- Replacements ---
-alias cat='bat'
+command -v bat >/dev/null 2>&1 && alias cat='bat'
 alias mkdir='mkdir -pv'
-alias cd='z'
+command -v zoxide >/dev/null 2>&1 && alias cd='z'
 alias grep='grep --color=auto'
 
 # --- Navigation ---
@@ -39,8 +44,8 @@ alias gp='git push'
 alias gl='git pull'
 
 # --- Tools ---
-alias lzg='lazygit'
-alias lzd='lazydocker'
+command -v lazygit >/dev/null 2>&1 && alias lzg='lazygit'
+command -v lazydocker >/dev/null 2>&1 && alias lzd='lazydocker'
 # n is defined as a function in .zsh_functions
 
 # --- Utilities ---

--- a/configs/zsh/.config/zsh/.zshrc
+++ b/configs/zsh/.config/zsh/.zshrc
@@ -20,49 +20,46 @@ setopt correct                # Auto-correct command names
 setopt nocaseglob             # Case-insensitive globbing
 
 # --- History Configuration ---
+mkdir -p "$XDG_STATE_HOME/zsh" "$XDG_CACHE_HOME/zsh"
 HISTFILE="${XDG_STATE_HOME}/zsh/history"
 HISTSIZE=10000
 SAVEHIST=10000
 
-# --- Zinit Plugin Manager ---
-# https://github.com/zdharma-continuum/zinit
-ZINIT_HOME="${XDG_DATA_HOME}/zinit/zinit.git"
-if [[ -f "$ZINIT_HOME/zinit.zsh" ]]; then
-  source "$ZINIT_HOME/zinit.zsh"
-else
-  echo "Zinit not found. Please install it at $ZINIT_HOME"
-fi
+# --- Completions ---
+autoload -Uz compinit
+compinit -d "$XDG_CACHE_HOME/zsh/zcompdump"
 
 # --- Plugins ---
-# Use `light` for minimal plugin loading
-# Use `wait` to defer loading after shell prompt shows
-
-zinit light zsh-users/zsh-autosuggestions       # Suggests commands as you type
-zinit light zsh-users/zsh-syntax-highlighting   # Highlights syntax errors
-zinit light zsh-users/zsh-completions           # Adds more completions
-zinit light djui/alias-tips                     # Reminds you of defined aliases
-zinit wait lucid for \
-  zdharma-continuum/fast-syntax-highlighting    # Faster highlighting
+ZSH_PLUGIN_DIR="${XDG_DATA_HOME}/zsh/plugins"
+if [[ -t 0 && -t 1 && -f "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh" ]]; then
+  source "$ZSH_PLUGIN_DIR/zsh-autosuggestions/zsh-autosuggestions.zsh"
+fi
 
 # --- Initialize zoxide ---
-eval "$(zoxide init zsh)"
+if command -v zoxide &>/dev/null; then
+  zoxide_init="$(zoxide init zsh 2>/dev/null)" && eval "$zoxide_init"
+  unset zoxide_init
+fi
 
 # --- Prompt (Starship) ---
 # https://starship.rs/
 if command -v starship &>/dev/null; then
-  eval "$(starship init zsh)"
+  starship_init="$(starship init zsh 2>/dev/null)" && eval "$starship_init"
+  unset starship_init
 fi
 
 # --- mise (language/runtime version manager) ---
 # Replaces NVM, SDKMAN, and other version managers
 # https://mise.jdx.dev/
-if command -v mise &>/dev/null; then
+if command -v mise &>/dev/null && mise hook-env -s zsh >/dev/null 2>&1; then
   eval "$(mise activate zsh)"
 fi
 
 # --- fzf ---
 export RIPGREP_CONFIG_PATH="$XDG_CONFIG_HOME/ripgrep/ripgreprc"
-[[ -f "$XDG_CONFIG_HOME/fzf/fzf.zsh" ]] && source "$XDG_CONFIG_HOME/fzf/fzf.zsh"
+if [[ -t 0 && -t 1 ]] && command -v fzf &>/dev/null && [[ -f "$XDG_CONFIG_HOME/fzf/fzf.zsh" ]]; then
+  source "$XDG_CONFIG_HOME/fzf/fzf.zsh"
+fi
 
 # --- opencode ---
 export PATH="$HOME/.opencode/bin:$PATH"
@@ -75,3 +72,8 @@ done
 
 # bun completions
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# zsh-syntax-highlighting must be sourced at the end of .zshrc.
+if [[ -t 0 && -t 1 && -f "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh" ]]; then
+  source "$ZSH_PLUGIN_DIR/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+fi

--- a/configs/zsh/.config/zsh/functions/update-env.zsh
+++ b/configs/zsh/.config/zsh/functions/update-env.zsh
@@ -1,8 +1,16 @@
 # Environment update helpers
 
 update-env() {
-  echo "Updating Zinit plugins..."
-  zinit self-update && zinit update --all
+  local plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/plugins"
+
+  for plugin in zsh-autosuggestions zsh-syntax-highlighting; do
+    if [ -d "$plugin_dir/$plugin/.git" ]; then
+      echo "Updating $plugin..."
+      git -C "$plugin_dir/$plugin" pull --ff-only
+    else
+      echo "Skipping $plugin; not installed at $plugin_dir/$plugin"
+    fi
+  done
 
   echo "Updating Starship..."
   if command -v starship &>/dev/null; then

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,7 @@ CLI/TUI:
 - `tmux`
 - `vim`
 - `zellij`
+- `zsh-plugins`
 - `zoxide`
 
 Agents:

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ CLI_APPS=(
   tmux
   vim
   zellij
+  zsh-plugins
   zoxide
 )
 AGENT_APPS=(claude codex copilot opencode pi)

--- a/install/apps/cli/zsh-plugins.sh
+++ b/install/apps/cli/zsh-plugins.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1090,SC1091
+source "${DOTFILES_DIR:?}/install/lib.sh"
+
+# Source policy: direct upstream git clones, following each plugin's manual install docs.
+# https://github.com/zsh-users/zsh-autosuggestions/blob/master/INSTALL.md
+# https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/INSTALL.md
+plugins_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/plugins"
+mkdir -p "$plugins_dir"
+
+clone_plugin() {
+  local name="$1"
+  local repo="$2"
+  local entrypoint="$3"
+  local dir="$plugins_dir/$name"
+
+  if [ -f "$dir/$entrypoint" ]; then
+    info "$name already installed"
+    return
+  fi
+
+  if [ -e "$dir" ]; then
+    die "$dir exists but does not contain $entrypoint"
+  fi
+
+  git clone --depth=1 "$repo" "$dir"
+  [ -f "$dir/$entrypoint" ] || die "$name clone completed but $entrypoint is missing"
+}
+
+clone_plugin \
+  zsh-autosuggestions \
+  https://github.com/zsh-users/zsh-autosuggestions.git \
+  zsh-autosuggestions.zsh
+
+clone_plugin \
+  zsh-syntax-highlighting \
+  https://github.com/zsh-users/zsh-syntax-highlighting.git \
+  zsh-syntax-highlighting.zsh

--- a/install/apps/cli/zsh.sh
+++ b/install/apps/cli/zsh.sh
@@ -4,15 +4,8 @@ set -euo pipefail
 # shellcheck disable=SC1090,SC1091
 source "${DOTFILES_DIR:?}/install/lib.sh"
 
-# Source policy: package-manager zsh plus zinit runtime plugin manager.
+# Source policy: package-manager zsh only; plugins are installed explicitly by zsh-plugins.sh.
 pkg_install zsh
-
-zinit_dir="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
-if [ -d "$zinit_dir" ]; then
-  info "Zinit already installed"
-else
-  git clone --depth=1 https://github.com/zdharma-continuum/zinit.git "$zinit_dir"
-fi
 
 zsh_path="$(command -v zsh || true)"
 if [ -z "$zsh_path" ]; then

--- a/install/lib.sh
+++ b/install/lib.sh
@@ -179,7 +179,10 @@ ensure_xdg_dirs() {
     "$HOME/.config" \
     "$HOME/.local/bin" \
     "$HOME/.local/share" \
+    "$HOME/.local/share/zsh/plugins" \
     "$HOME/.local/state" \
+    "$HOME/.local/state/zsh" \
+    "$HOME/.cache/zsh" \
     "$HOME/.cache"
 }
 


### PR DESCRIPTION
## Summary
Remove Zinit from the zsh setup and replace it with explicit manual upstream clones for the two shell plugins that are still wanted: autosuggestions and syntax highlighting. The shell startup path is also more defensive so optional tools do not produce repeated startup noise when a tolerant installer fails or a command is unavailable.

## Changes
- Removed Zinit cloning from the zsh installer and removed Zinit plugin loading from `.zshrc`.
- Added `install/apps/cli/zsh-plugins.sh` to clone `zsh-autosuggestions` and `zsh-syntax-highlighting` into `$XDG_DATA_HOME/zsh/plugins` only when missing.
- Added native `compinit` setup and kept `zsh-syntax-highlighting` sourced last.
- Updated `update-env` to pull the two explicit plugin repos and upgrade Starship when available.
- Guarded zoxide, Starship, mise, fzf integration, shell aliases, and fzf previews so missing optional tools degrade cleanly.
- Removed the hardcoded `/bin/zsh` tmux default shell and documented `zsh-plugins` as a managed CLI component.

## Testing
**Automated**
- [x] `bash scripts/validate.sh` passed, including `shfmt` and `shellcheck`

**Manual**
- [x] `zsh -i -c 'echo current-zsh-ok'` starts without startup noise
- [x] Restricted PATH zsh smoke test starts cleanly with optional tools unavailable
- [x] `install/apps/cli/zsh-plugins.sh` cloned both plugins successfully in a temporary home

## Notes
GitHub issues were also cleaned up to match the current architecture: handled/stale issues were closed and the remaining open issues were rewritten around the current `install/apps`, `install/stow.sh`, and platform-hardening flow.