### PR TITLE
fix(zsh): move go paths under xdg directories

### DIFF
--- a/configs/zsh/.config/zsh/.zshenv
+++ b/configs/zsh/.config/zsh/.zshenv
@@ -1,0 +1,14 @@
+# ~/.config/zsh/.zshenv
+# Shared zsh environment loaded through ZDOTDIR.
+
+export XDG_CONFIG_HOME="$HOME/.config"
+export XDG_DATA_HOME="$HOME/.local/share"
+export XDG_CACHE_HOME="$HOME/.cache"
+export XDG_STATE_HOME="$HOME/.local/state"
+export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+
+# Keep Go's mutable workspace and caches under XDG directories instead of ~/go.
+export GOPATH="${GOPATH:-$XDG_DATA_HOME/go}"
+export GOBIN="${GOBIN:-$HOME/.local/bin}"
+export GOMODCACHE="${GOMODCACHE:-$XDG_CACHE_HOME/go/pkg/mod}"
+export GOCACHE="${GOCACHE:-$XDG_CACHE_HOME/go-build}"

--- a/configs/zsh/.zshenv
+++ b/configs/zsh/.zshenv
@@ -9,3 +9,7 @@ export XDG_DATA_HOME="$HOME/.local/share"
 export XDG_CACHE_HOME="$HOME/.cache"
 export XDG_STATE_HOME="$HOME/.local/state"
 export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+
+if [ -r "$ZDOTDIR/.zshenv" ]; then
+  source "$ZDOTDIR/.zshenv"
+fi

--- a/install/lib.sh
+++ b/install/lib.sh
@@ -179,9 +179,12 @@ ensure_xdg_dirs() {
     "$HOME/.config" \
     "$HOME/.local/bin" \
     "$HOME/.local/share" \
+    "$HOME/.local/share/go" \
     "$HOME/.local/share/zsh/plugins" \
     "$HOME/.local/state" \
     "$HOME/.local/state/zsh" \
+    "$HOME/.cache/go/pkg/mod" \
+    "$HOME/.cache/go-build" \
     "$HOME/.cache/zsh" \
     "$HOME/.cache"
 }


### PR DESCRIPTION
## Summary
Move Go's mutable workspace and caches out of the visible `~/go` default and into XDG-aligned locations. This keeps `GOPATH` under `~/.local/share`, module downloads under `~/.cache`, and Go-installed commands in `~/.local/bin`.

## Changes
- Added `$ZDOTDIR/.zshenv` so nested zsh shells load the same environment when `ZDOTDIR` is already exported.
- Updated the root `.zshenv` to bootstrap the shared zsh environment file.
- Ensured the installer creates the Go XDG data/cache directories.

## Testing
- `bash -n install/lib.sh`
- `zsh -n configs/zsh/.zshenv`
- `zsh -n configs/zsh/.config/zsh/.zshenv`
- `shellcheck install/lib.sh`
- Verified `go env` reports XDG paths when `ZDOTDIR` points at the repo zsh config.
- Verified a simulated stowed home loads the same Go environment through root `.zshenv`.